### PR TITLE
Show banned players in a home page filter

### DIFF
--- a/app/assets/javascripts/filters.js.coffee
+++ b/app/assets/javascripts/filters.js.coffee
@@ -19,6 +19,7 @@ FILTERS =
     'eligible-2021': '.eligible-2021'
     'active-and-worthy': '.active-and-worthy.not-hos',
     'active-and-close': '.active-and-close',
+    'banned': '.banned',
     'near-misses': '.near-miss',
     'position': '.position',
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,7 @@ module ApplicationHelper
       eligible_2021:      'Eligible in 2021',
       active_and_worthy:  'Active and Hall-worthy',
       active_and_close:   'Active and Close',
+      banned:             'Banned',
       near_misses:        'Near Misses'
     }
   end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -75,6 +75,7 @@ class Player < ActiveRecord::Base
   scope :eligible_2021, not_in_hos.where("eligibility = 'upcoming' AND hall_rating >= 20 AND last_year = 2015")
   scope :active_and_worthy, not_in_hos.hall_worthy.where("eligibility = 'active'")
   scope :active_and_close, not_in_hos.where("eligibility = 'active' AND hall_rating >= 75 AND hall_rating <= 100.0")
+  scope :banned, not_in_hos.where("eligibility = 'banned'")
   scope :near_misses, not_in_hos.where("eligibility != 'active' AND hall_rating >= 90 AND hall_rating <= 100.0")
 
   scope :all_but_hof, not_in_hof.where("consensus = 7")
@@ -171,6 +172,10 @@ class Player < ActiveRecord::Base
 
   def active_and_close?
     !hos && (eligibility == 'active') && hall_rating.between?(75, 100.0)
+  end
+
+  def banned?
+    !hos && (eligibility == 'banned')
   end
 
   def near_miss?

--- a/app/models/player_filter.rb
+++ b/app/models/player_filter.rb
@@ -20,6 +20,7 @@ module PlayerFilter
       eligible_2021,
       active_and_worthy,
       active_and_close,
+      banned,
       near_miss
     ].compact
   end
@@ -92,6 +93,10 @@ module PlayerFilter
 
   def self.active_and_close
     'active-and-close' if @player.active_and_close?
+  end
+
+  def self.banned
+    'banned' if @player.banned?
   end
 
   def self.near_miss


### PR DESCRIPTION
Definitely no rush on this… I just figured I'd put a filter on the home page for the new Banned designation. I have it most of the way, but it's only showing players with a Hall Rating over 100. I forget what I'm doing wrong here. Any tips @semanticart?

<img width="486" alt="screen shot 2016-08-19 at 7 59 59 am" src="https://cloud.githubusercontent.com/assets/138720/17809244/317f1d88-65e3-11e6-9327-4b7b72aa77fd.png">
